### PR TITLE
Rewrite to use new Lua completion API

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,7 @@ const { sources, workspace } = require("coc.nvim");
 const { nvim } = workspace;
 
 async function completions(input) {
-  const p = await nvim.lua("return require('conjure.eval')['completions-promise'](...)", input)
-  await nvim.lua("require('conjure.promise').await(...)", p)
-  return nvim.lua("return require('conjure.promise').close(...)", p)
+  return nvim.lua("return require('conjure.eval')['completions-sync'](...)", input)
 }
 
 exports.activate = async context => {

--- a/index.js
+++ b/index.js
@@ -1,8 +1,24 @@
 const { sources, workspace } = require("coc.nvim");
 const { nvim } = workspace;
 
+async function lua(mod, f, arg) {
+  return nvim.lua("return require('" + mod + "')['" + f + "'](...)", arg)
+}
+
+async function snooze(ms) {
+  return new Promise((res) => {
+    setTimeout(res, ms)
+  })
+}
+
 async function completions(input) {
-  return nvim.lua("return require('conjure.eval')['completions-sync'](...)", input)
+  const p = await lua("conjure.eval", "completions-promise", input)
+
+  while (!await lua("conjure.promise", "done?", p)) {
+    await snooze(20)
+  }
+
+  return lua("conjure.promise", "close", p)
 }
 
 exports.activate = async context => {

--- a/index.js
+++ b/index.js
@@ -1,58 +1,21 @@
 const { sources, workspace } = require("coc.nvim");
-const { Socket } = require("net");
+const { nvim } = workspace;
 
-function sendMessage(client, message) {
-  let receivedData = "";
-  return new Promise((resolve, reject) => {
-    client.write(message);
-
-    client.on("data", data => {
-      receivedData += data.toString("utf8");
-      if (receivedData.endsWith("\n")) resolve(receivedData);
-    });
-
-    client.on("error", err => {
-      reject(err);
-    });
-  });
+async function completions(input) {
+  const p = await nvim.lua("return require('conjure.eval')['completions-promise'](...)", input)
+  await nvim.lua("require('conjure.promise').await(...)", p)
+  return nvim.lua("return require('conjure.promise').close(...)", p)
 }
 
 exports.activate = async context => {
-  const { nvim } = workspace;
-  let client = null;
-
-  async function newClient() {
-    const client = new Socket();
-    const port = await nvim.eval("conjure#get_rpc_port()");
-    client.connect(port, "127.0.0.1");
-    return client;
-  }
-
-  async function conjureCompletions(input) {
-    if (client == null) {
-      client = await newClient();
-    }
-    // See
-    // https://github.com/Olical/conjure/blob/master/rplugin/python3/deoplete/sources/conjure.py
-    const req = [0, 1, "completions", [input]];
-
-    const response = await sendMessage(client, JSON.stringify(req));
-    // context.logger.info(response);
-    return JSON.parse(response)[3];
-  }
-
   context.subscriptions.push(
     sources.createSource({
       name: "conjure",
       triggerCharacters: [".", "/", ":"],
       doComplete: async function(opt) {
-        const autocomplete = await nvim.eval("conjure#should_autocomplete()");
         const input = opt.input;
-        if (!input || autocomplete === 0) return null;
-        const res = await conjureCompletions(input);
-
-        // e.g.:
-        // {word: "inc", kind: "f", menu: "clojure.core"}
+        if (!input) return null;
+        const res = await completions(input);
         if (!res || res.length === 0) return null;
         return { items: res };
       }


### PR DESCRIPTION
The new Conjure implementation is quite a bit simpler since it all takes place within the Neovim thread. I've just hooked directly into the Lua functions, seems to work great! Interested in hearing your feedback, feel free to change the code entirely, just wanted to get it working and show you how it worked first.

I've published this version to `coc-conjure-olical` as a temporary way to try it out too.

This will _only_ work against the develop branch of Conjure which will be going to master after I've finished the documentation and everyone's happy with the initial feature set. Maybe this could go to a develop branch or just not be published until the rewrite is all done and fully released?