### PR TITLE
fix: update doComplete api to coc v0.0.79

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,12 @@ exports.activate = async (context) => {
         if (!input) return null;
         const res = await completions(input);
         if (!res || res.length === 0) return null;
-        return { items: res };
+        return {
+          items: res.map((word) => ({
+            word,
+            menu: this.menu,
+          })),
+        };
       },
     })
   );


### PR DESCRIPTION
api for doComplete has been updated to expect an array of objects and no longer accepts an array of strings. This PR updates the return value. It also ensures res is an array to prevent type errors.

closes #6 