### PR TITLE
fix: map String[] results to VimCompleteItem[]

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,10 +34,11 @@ exports.activate = async (context) => {
         const res = await completions(input);
         if (!res || res.length === 0) return null;
         return {
-          items: res.map((word) => ({
-            ...word,
-            menu: this.menu,
-          })),
+          items: res.map((word) => typeof word === 'string' ? ({ word }) : word)
+            .map((word) => ({
+              ...word,
+              menu: word.menu || this.menu,
+            })),
         };
       },
     })


### PR DESCRIPTION
closes #8 

![image](https://user-images.githubusercontent.com/6775919/94870667-0034c680-03fd-11eb-965e-916e39d17ca1.png)
