### PR TITLE
Support latest coc.nvim with function name change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.0.1 (2022-02-11)
+
+- Support latest `coc.nvim` which has changed the function from `nvim.lua`
+  to `nvim.executeLua`.
+
 ## 3.0.0 (2020-05-04)
 
 - Support [Conjure v3](https://github.com/Olical/conjure/releases/tag/v3.0.0).

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const { sources, workspace } = require("coc.nvim");
 const { nvim } = workspace;
 
 async function lua(mod, f, arg) {
-  return nvim.lua("return require('" + mod + "')['" + f + "'](...)", arg);
+  return nvim.executeLua("return require('" + mod + "')['" + f + "'](...)", [arg]);
 }
 
 async function snooze(ms) {


### PR DESCRIPTION
The latest coc.nvim has changed the function name from `nvim.lua` to
`nvim.executeLua`.

Fixes #16 

-=david=-